### PR TITLE
Add simple mouse + keyboard UI

### DIFF
--- a/vga.c
+++ b/vga.c
@@ -109,3 +109,12 @@ void vga_write_str(int row, int col, const char* str, uint8_t color) {
 void vga_set_default_color(uint8_t color) {
     default_color = color;
 }
+
+// --- DIRECT CELL ACCESS ---
+uint16_t vga_get_cell(int row, int col) {
+    return vga_buffer[row * VGA_WIDTH + col];
+}
+
+void vga_set_cell(int row, int col, uint16_t val) {
+    vga_buffer[row * VGA_WIDTH + col] = val;
+}


### PR DESCRIPTION
## Summary
- expose VGA cell get/set functions
- add a simple UI to test the PS/2 mouse and keyboard

## Testing
- `python3 setup_bootloader.py` *(fails: FileNotFoundError for i686-elf-gcc.exe)*

------
https://chatgpt.com/codex/tasks/task_e_684cbcad8774832f9118d0216466c849