### PR TITLE
Fix IDT setup order to prevent boot loop

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -84,6 +84,8 @@ bool mouse_read_packet(uint8_t packet[3]) {
     return false;
 }
 
+// Detect basic PS/2 devices. Call only after the IDT is installed to
+// avoid unexpected interrupts resetting the CPU.
 void hardware_init(void) {
     has_keyboard = true;
     mouse_enable();

--- a/hardware.h
+++ b/hardware.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// Initialize keyboard/mouse. IDT should be ready before calling.
 void hardware_init(void);
 
 // Keyboard

--- a/kernel_main.c
+++ b/kernel_main.c
@@ -163,6 +163,9 @@ void kmain() {
     vga_set_default_color(blue_white);
     vga_clear(blue_white);
 
+    // --- INITIALIZE IDT BEFORE ENABLING DEVICES ---
+    idt_init();
+
     // --- HARDWARE INIT ---
     hardware_init();
 
@@ -221,8 +224,6 @@ void kmain() {
     row++;
     vga_center_puts(row++, "IDT/Exception Test (Divide by Zero)", blue_white);
     vga_center_puts(row++, "Triggering exception in 2 seconds...", red_yellow);
-
-    idt_init();
 
     for (volatile int i = 0; i < 50000000; ++i);
 


### PR DESCRIPTION
## Summary
- call `idt_init()` before enabling PS/2 devices
- document hardware initialization requirements
- clarify when `hardware_init()` should be used

## Testing
- `clang -m32 -ffreestanding -c kernel_main.c -o /tmp/test.o`
- `clang -m32 -ffreestanding -c hardware.c -o /tmp/hardware.o`
- `qemu-system-x86_64 -cdrom OptrixOS.iso -display none -serial stdio -no-reboot -d guest_errors -no-reboot` *(fails: could not connect serial device)*

------
https://chatgpt.com/codex/tasks/task_e_684cc3872d3c832f8d975666f7aa745b