### PR TITLE
Fix IDT setup and handler

### DIFF
--- a/idt.asm
+++ b/idt.asm
@@ -2,7 +2,22 @@
 BITS 32
 
 global idt_load
-global isr0
+%macro ISR_NOERR 1
+global isr%1
+isr%1:
+    push dword 0          ; error code
+    push dword %1         ; interrupt number
+    call isr_handler
+    add esp, 8
+    iret
+%endmacro
+
+; Declare all ISR stubs 0-31
+%assign i 0
+%rep 32
+    ISR_NOERR i
+%assign i i+1
+%endrep
 
 extern isr_handler
 
@@ -14,10 +29,3 @@ idt_load:
     lidt [eax]
     ret
 
-; ISR0: Divide by zero handler
-isr0:
-    push 0         ; dummy error code
-    push 0         ; interrupt number 0
-    call isr_handler
-    add esp, 8
-    iret

--- a/idt.c
+++ b/idt.c
@@ -19,6 +19,37 @@ struct IDTPointer {
 
 // --- Forward declarations for ASM symbols ---
 extern void isr0(void);
+extern void isr1(void);
+extern void isr2(void);
+extern void isr3(void);
+extern void isr4(void);
+extern void isr5(void);
+extern void isr6(void);
+extern void isr7(void);
+extern void isr8(void);
+extern void isr9(void);
+extern void isr10(void);
+extern void isr11(void);
+extern void isr12(void);
+extern void isr13(void);
+extern void isr14(void);
+extern void isr15(void);
+extern void isr16(void);
+extern void isr17(void);
+extern void isr18(void);
+extern void isr19(void);
+extern void isr20(void);
+extern void isr21(void);
+extern void isr22(void);
+extern void isr23(void);
+extern void isr24(void);
+extern void isr25(void);
+extern void isr26(void);
+extern void isr27(void);
+extern void isr28(void);
+extern void isr29(void);
+extern void isr30(void);
+extern void isr31(void);
 extern void idt_load(struct IDTPointer* idt_ptr);
 
 // --- IDT table ---
@@ -48,14 +79,24 @@ void isr_handler_c(int int_no) {
 }
 
 // --- Symbol called from ASM ---
-void isr_handler() {
-    isr_handler_c(0); // Just pass 0 for now (interrupt number)
+void isr_handler(int int_no, int err_code) {
+    (void)err_code;
+    isr_handler_c(int_no);
 }
 
 // --- Initialize IDT ---
+static void (*isr_table[32])(void) = {
+    isr0,  isr1,  isr2,  isr3,  isr4,  isr5,  isr6,  isr7,
+    isr8,  isr9,  isr10, isr11, isr12, isr13, isr14, isr15,
+    isr16, isr17, isr18, isr19, isr20, isr21, isr22, isr23,
+    isr24, isr25, isr26, isr27, isr28, isr29, isr30, isr31
+};
+
 void idt_init() {
-    for (int i = 0; i < IDT_ENTRIES; ++i)
-        idt_set_gate(i, (uint32_t)isr0);
+    for (int i = 0; i < 32; ++i)
+        idt_set_gate(i, (uint32_t)isr_table[i]);
+    for (int i = 32; i < IDT_ENTRIES; ++i)
+        idt_set_gate(i, (uint32_t)isr_table[0]);
 
     struct IDTPointer idt_ptr;
     idt_ptr.limit = sizeof(struct IDTEntry) * IDT_ENTRIES - 1;


### PR DESCRIPTION
## Summary
- implement generic ISR stubs for interrupts 0-31
- expose all ISR stubs in C and build table
- pass interrupt numbers correctly to the handler

## Testing
- `nasm -f bin bootloader.asm -o bootloader.bin`
- `nasm -felf32 kernel.asm -o kernel_stubs.o`
- `nasm -felf32 idt.asm -o idt_stubs.o`
- `gcc -ffreestanding -m32 -fno-pie -c kernel_main.c -o kernel_main.o`
- `gcc -ffreestanding -m32 -fno-pie -c vga.c -o vga.o`
- `gcc -ffreestanding -m32 -fno-pie -c pmm.c -o pmm.o`
- `gcc -ffreestanding -m32 -fno-pie -c idt.c -o idt.o`
- `gcc -ffreestanding -m32 -fno-pie -c hardware.c -o hardware.o`
- `ld -Ttext 0x1000 -m elf_i386 -e start kernel_stubs.o idt_stubs.o kernel_main.o vga.o pmm.o idt.o hardware.o -o kernel.elf`
- `ld -Ttext 0x1000 -m elf_i386 -e start --oformat binary kernel_stubs.o idt_stubs.o kernel_main.o vga.o pmm.o idt.o hardware.o -o kernel.bin`


------
https://chatgpt.com/codex/tasks/task_e_684cc7a79774832fb3acf7bc24538220