### PR TITLE
Fix build errors from leftover merge markers

### DIFF
--- a/hardware.c
+++ b/hardware.c
@@ -35,15 +35,8 @@ bool keyboard_available(void) { return has_keyboard; }
 
 void keyboard_enable(void) {
     ps2_wait_input();
-    uhu5r1-codex/fix-mouse-and-keyboard-functionality
     outb(PS2_CMD, 0xAE); // enable first PS/2 port
     ps2_wait_input();
-=======
-    e3wlqv-codex/fix-mouse-and-keyboard-functionality
-    outb(PS2_CMD, 0xAE); // enable first PS/2 port
-    ps2_wait_input();
-=======
-    main
     outb(PS2_DATA, 0xF4); // enable scanning
     ps2_wait_output();
     uint8_t ack = inb(PS2_DATA);

--- a/hardware.h
+++ b/hardware.h
@@ -8,15 +8,9 @@
 void hardware_init(void);
 
 // Keyboard
-uhu5r1-codex/fix-mouse-and-keyboard-functionality
 bool keyboard_available(void);
 void keyboard_enable(void);
 uint8_t keyboard_read_scan(void);
-=======
-bool keyboard_available(void);
-void keyboard_enable(void);
-uint8_t keyboard_read_scan(void);
-main
 
 // Mouse
 bool mouse_available(void);


### PR DESCRIPTION
## Summary
- clean up merge artifacts in `hardware.h`
- remove conflict text in `hardware.c`

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684cd29fdb18832f8a4048a9e768d709