### PR TITLE
Improve PS/2 detection and VGA cursor

### DIFF
--- a/kernel_main.c
+++ b/kernel_main.c
@@ -12,6 +12,7 @@ void vga_set_default_color(uint8_t color);
 void vga_move_cursor(int row, int col);
 uint16_t vga_get_cell(int row, int col);
 void vga_set_cell(int row, int col, uint16_t val);
+void vga_enable_cursor(void);
 
 // --- pmm.c prototypes ---
 void init_pmm(uint32_t kernel_end_addr);
@@ -185,6 +186,7 @@ static void boot_sequence(struct BootInfo* boot, uint8_t color) {
     int row = 2;
     vga_set_default_color(color);
     vga_clear(color);
+    vga_enable_cursor();
     vga_center_puts(row++, "=== OptrixOS Boot ===", color);
 
     char mem_msg[] = "BIOS Memory KB: ";
@@ -200,16 +202,14 @@ static void boot_sequence(struct BootInfo* boot, uint8_t color) {
     vga_center_puts(row++, "IDT ready", color);
     wait_2s();
 
-    vga_center_puts(row++, "Enabling keyboard...", color);
+    vga_center_puts(row++, "Detecting input devices...", color);
     wait_2s();
-    keyboard_enable();
-    vga_center_puts(row++, keyboard_available() ? "Keyboard detected" : "Keyboard missing", color);
+    hardware_init();
+    const char* kmsg = keyboard_available() ? "Keyboard detected" : "Keyboard missing";
+    const char* mmsg = mouse_available() ? "Mouse detected" : "Mouse missing";
+    vga_center_puts(row++, kmsg, color);
     wait_2s();
-
-    vga_center_puts(row++, "Enabling mouse...", color);
-    wait_2s();
-    mouse_enable();
-    vga_center_puts(row++, mouse_available() ? "Mouse detected" : "Mouse missing", color);
+    vga_center_puts(row++, mmsg, color);
     wait_2s();
 }
 

--- a/vga.c
+++ b/vga.c
@@ -6,6 +6,12 @@ static inline void outb(uint16_t port, uint8_t val) {
     __asm__ volatile ("outb %0, %1" : : "a"(val), "Nd"(port));
 }
 
+static inline uint8_t inb(uint16_t port) {
+    uint8_t val;
+    __asm__ volatile ("inb %1, %0" : "=a"(val) : "Nd"(port));
+    return val;
+}
+
 // --- VGA DEFINITIONS ---
 #define VGA_WIDTH 80
 #define VGA_HEIGHT 25
@@ -35,6 +41,13 @@ static int cursor_row = 0, cursor_col = 0;
 static uint8_t default_color = (VGA_BLUE << 4) | VGA_WHITE;
 
 // --- CURSOR CONTROL ---
+void vga_enable_cursor(void) {
+    outb(0x3D4, 0x0A);
+    outb(0x3D5, (inb(0x3D5) & 0xC0));
+    outb(0x3D4, 0x0B);
+    outb(0x3D5, (inb(0x3D5) & 0xE0) | 15);
+}
+
 void vga_move_cursor(int row, int col) {
     uint16_t pos = row * VGA_WIDTH + col;
     outb(0x3D4, 0x0F);


### PR DESCRIPTION
## Summary
- add PS/2 controller self‑test and port testing routines
- use those routines during `hardware_init`
- expose and use `vga_enable_cursor` to show hardware cursor
- update boot sequence to call the new detection logic

## Testing
- `python3 setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_684cd40b9788832fabb629a4502f2744