### PR TITLE
Add basic Fabric UI demo

### DIFF
--- a/fabric.c
+++ b/fabric.c
@@ -1,0 +1,113 @@
+#include <stdint.h>
+#include "hardware.h"
+#include "fabric.h"
+
+void vga_clear(uint8_t color);
+void vga_puts(const char* str, uint8_t color);
+void vga_move_cursor(int row, int col);
+uint16_t vga_get_cell(int row, int col);
+void vga_set_cell(int row, int col, uint16_t val);
+
+static const char scancode_ascii[128] = {
+    0, 27,'1','2','3','4','5','6','7','8','9','0','-','=','\b',
+    '\t','q','w','e','r','t','y','u','i','o','p','[',']','\n',0,
+    'a','s','d','f','g','h','j','k','l',';','\'','`',0,'\\',
+    'z','x','c','v','b','n','m',',','.','/',0,'*',0,' ',
+    0,0,0,0,0,0,0,'7','8','9','-','4','5','6','+','1',
+    '2','3','0','.','\\',0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0x81,0x82,0,0
+};
+
+// Draw a simple bordered window filling most of the screen
+static void draw_window(uint8_t color) {
+    const int top = 1;
+    const int left = 1;
+    const int bottom = VGA_HEIGHT - 2;
+    const int right = VGA_WIDTH - 2;
+
+    for (int x = left; x <= right; ++x) {
+        vga_set_cell(top, x, ((uint16_t)color << 8) | '-');
+        vga_set_cell(bottom, x, ((uint16_t)color << 8) | '-');
+    }
+    for (int y = top; y <= bottom; ++y) {
+        vga_set_cell(y, left, ((uint16_t)color << 8) | '|');
+        vga_set_cell(y, right, ((uint16_t)color << 8) | '|');
+    }
+    vga_set_cell(top, left, ((uint16_t)color << 8) | '+');
+    vga_set_cell(top, right, ((uint16_t)color << 8) | '+');
+    vga_set_cell(bottom, left, ((uint16_t)color << 8) | '+');
+    vga_set_cell(bottom, right, ((uint16_t)color << 8) | '+');
+
+    const char *title = "Fabric Terminal";
+    vga_move_cursor(top, (VGA_WIDTH - 14) / 2);
+    vga_puts(title, color);
+}
+
+void fabric_ui(uint8_t color) {
+    vga_clear(color);
+    draw_window(color);
+
+    int mouse_row = VGA_HEIGHT / 2;
+    int mouse_col = VGA_WIDTH / 2;
+    uint16_t prev_cell = vga_get_cell(mouse_row, mouse_col);
+    uint16_t cursor_val = (color << 8) | 'X';
+    vga_set_cell(mouse_row, mouse_col, cursor_val);
+
+    int term_row = VGA_HEIGHT - 3;
+    int term_col = 2;
+    vga_move_cursor(term_row, term_col);
+    const char *prompt = "Press ESC to exit > ";
+    vga_puts(prompt, color);
+    term_col += 20; // strlen(prompt)
+    char line[80];
+    int linepos = 0;
+
+    while (1) {
+        uint8_t packet[3];
+        if (mouse_available() && mouse_read_packet(packet)) {
+            int dx = (int8_t)packet[1];
+            int dy = (int8_t)packet[2];
+            vga_set_cell(mouse_row, mouse_col, prev_cell);
+            mouse_col += dx / 2;
+            mouse_row -= dy / 2;
+            if (mouse_col < 2) mouse_col = 2;
+            if (mouse_row < 2) mouse_row = 2;
+            if (mouse_col >= VGA_WIDTH - 2) mouse_col = VGA_WIDTH - 3;
+            if (mouse_row >= VGA_HEIGHT - 3) mouse_row = VGA_HEIGHT - 4;
+            prev_cell = vga_get_cell(mouse_row, mouse_col);
+            vga_set_cell(mouse_row, mouse_col, cursor_val);
+        }
+
+        uint8_t sc = keyboard_read_scan();
+        if (sc && sc < 0x80) {
+            char ch = scancode_ascii[sc];
+            if (ch == 27) {
+                vga_set_cell(mouse_row, mouse_col, prev_cell);
+                break;
+            }
+            if (ch) {
+                if (ch == '\n') {
+                    vga_puts("\n", color);
+                    term_row++;
+                    term_col = 2;
+                    vga_move_cursor(term_row, term_col);
+                    line[linepos] = 0;
+                    linepos = 0;
+                } else if (ch == '\b') {
+                    if (linepos > 0 && term_col > 2) {
+                        --linepos; --term_col; vga_move_cursor(term_row, term_col);
+                        vga_puts(" ", color); vga_move_cursor(term_row, term_col);
+                    }
+                } else if (linepos < (int)(sizeof(line)-1)) {
+                    line[linepos++] = ch;
+                    char s[2] = {ch, 0};
+                    vga_puts(s, color);
+                    term_col++;
+                }
+            }
+        }
+    }
+}
+

--- a/fabric.h
+++ b/fabric.h
@@ -1,0 +1,9 @@
+#ifndef FABRIC_H
+#define FABRIC_H
+
+#include <stdint.h>
+
+// Simple text mode UI that displays a window with mouse and keyboard support
+void fabric_ui(uint8_t color);
+
+#endif

--- a/kernel.asm
+++ b/kernel.asm
@@ -12,6 +12,8 @@ start:
     call kmain
 
 .hang:
+    cli
+    hlt
     jmp .hang
 
 section .bss

--- a/kernel_main.c
+++ b/kernel_main.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include "hardware.h"
+#include "fabric.h"
 
 // VGA dimensions
 #define VGA_WIDTH 80
@@ -125,55 +126,6 @@ void command_line_shell(uint8_t color) {
     }
 }
 
-// === Simple mouse & keyboard test UI ===
-void ui_mouse_terminal(uint8_t color) {
-    int mouse_row = VGA_HEIGHT / 2;
-    int mouse_col = VGA_WIDTH / 2;
-    uint16_t prev_cell = vga_get_cell(mouse_row, mouse_col);
-    uint16_t cursor_val = (color << 8) | 'X';
-    vga_set_cell(mouse_row, mouse_col, cursor_val);
-
-    int term_row = VGA_HEIGHT - 1;
-    int term_col = 0;
-    vga_move_cursor(term_row, term_col);
-    vga_puts("Press ESC to exit > ", color);
-    term_col = kstrlen("Press ESC to exit > ");
-    char line[80];
-    int linepos = 0;
-
-    while (1) {
-        uint8_t packet[3];
-        if (mouse_available() && mouse_read_packet(packet)) {
-            int dx = (int8_t)packet[1];
-            int dy = (int8_t)packet[2];
-            vga_set_cell(mouse_row, mouse_col, prev_cell);
-            mouse_col += dx / 2;
-            mouse_row -= dy / 2;
-            if (mouse_col < 0) mouse_col = 0;
-            if (mouse_row < 0) mouse_row = 0;
-            if (mouse_col >= VGA_WIDTH) mouse_col = VGA_WIDTH - 1;
-            if (mouse_row >= VGA_HEIGHT - 1) mouse_row = VGA_HEIGHT - 2;
-            prev_cell = vga_get_cell(mouse_row, mouse_col);
-            vga_set_cell(mouse_row, mouse_col, cursor_val);
-        }
-
-        uint8_t sc = keyboard_read_scan();
-        if (sc && sc < 0x80) {
-            char ch = scancode_ascii[sc];
-            if (ch == 27) { // ESC
-                vga_set_cell(mouse_row, mouse_col, prev_cell);
-                break;
-            }
-            if (ch && linepos < (int)(sizeof(line)-1)) {
-                line[linepos++] = ch;
-                char s[2] = {ch, 0};
-                vga_puts(s, color);
-                term_col++;
-            }
-        }
-    }
-}
-
 struct BootInfo {
     uint32_t mem_kb;
 };
@@ -220,5 +172,5 @@ void kmain(struct BootInfo* boot) {
     boot_sequence(boot, blue_white);
 
     // Launch mouse/keyboard test UI
-    ui_mouse_terminal(blue_white);
+    fabric_ui(blue_white);
 }

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -33,7 +33,8 @@ c_files = [
     "vga.c",
     "pmm.c",
     "idt.c",
-    "hardware.c"
+    "hardware.c",
+    "fabric.c"
 ]
 
 tmp_files = []


### PR DESCRIPTION
## Summary
- provide a small text UI named Fabric with mouse/keyboard handling
- use Fabric in the kernel instead of the old test UI
- include Fabric sources in the build script
- small change to kernel hang loop

## Testing
- `python3 setup_bootloader.py` *(fails: `i686-linux-gnu-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd6323ebc832fb953bd4b947a274e