### PR TITLE
Create VGA header for shared constants

### DIFF
--- a/fabric.c
+++ b/fabric.c
@@ -1,12 +1,7 @@
 #include <stdint.h>
 #include "hardware.h"
 #include "fabric.h"
-
-void vga_clear(uint8_t color);
-void vga_puts(const char* str, uint8_t color);
-void vga_move_cursor(int row, int col);
-uint16_t vga_get_cell(int row, int col);
-void vga_set_cell(int row, int col, uint16_t val);
+#include "vga.h"
 
 static const char scancode_ascii[128] = {
     0, 27,'1','2','3','4','5','6','7','8','9','0','-','=','\b',

--- a/kernel_main.c
+++ b/kernel_main.c
@@ -1,20 +1,7 @@
 #include <stdint.h>
 #include "hardware.h"
 #include "fabric.h"
-
-// VGA dimensions
-#define VGA_WIDTH 80
-#define VGA_HEIGHT 25
-
-// --- vga.c prototypes ---
-void vga_clear(uint8_t color);
-void vga_puts(const char* str, uint8_t color);
-void vga_set_default_color(uint8_t color);
-void vga_move_cursor(int row, int col);
-uint16_t vga_get_cell(int row, int col);
-void vga_set_cell(int row, int col, uint16_t val);
-void vga_enable_cursor(void);
-
+#include "vga.h"
 // --- pmm.c prototypes ---
 void init_pmm(uint32_t kernel_end_addr);
 uint32_t alloc_frame(void);

--- a/vga.h
+++ b/vga.h
@@ -1,0 +1,41 @@
+#ifndef VGA_H
+#define VGA_H
+
+#include <stdint.h>
+
+// VGA text mode constants
+#define VGA_WIDTH 80
+#define VGA_HEIGHT 25
+#define VGA_ADDRESS 0xB8000
+
+enum VGAColor {
+    VGA_BLACK = 0,
+    VGA_BLUE = 1,
+    VGA_GREEN = 2,
+    VGA_CYAN = 3,
+    VGA_RED = 4,
+    VGA_MAGENTA = 5,
+    VGA_BROWN = 6,
+    VGA_LIGHT_GREY = 7,
+    VGA_DARK_GREY = 8,
+    VGA_LIGHT_BLUE = 9,
+    VGA_LIGHT_GREEN = 10,
+    VGA_LIGHT_CYAN = 11,
+    VGA_LIGHT_RED = 12,
+    VGA_LIGHT_MAGENTA = 13,
+    VGA_YELLOW = 14,
+    VGA_WHITE = 15,
+};
+
+// Basic VGA text functions
+void vga_enable_cursor(void);
+void vga_move_cursor(int row, int col);
+void vga_clear(uint8_t color);
+void vga_putc(char c, uint8_t color);
+void vga_puts(const char* str, uint8_t color);
+void vga_write_str(int row, int col, const char* str, uint8_t color);
+void vga_set_default_color(uint8_t color);
+uint16_t vga_get_cell(int row, int col);
+void vga_set_cell(int row, int col, uint16_t val);
+
+#endif // VGA_H


### PR DESCRIPTION
## Summary
- add `vga.h` defining VGA constants and function prototypes
- include `vga.h` from `fabric.c` and `kernel_main.c`
- remove duplicated definitions in individual files

## Testing
- `python3 setup_bootloader.py` *(fails: FileNotFoundError: 'i686-linux-gnu-gcc')*

------
https://chatgpt.com/codex/tasks/task_e_684cd78614a4832fa071875fdba4394f