### PR TITLE
Refactor drivers and fix boot loader

### DIFF
--- a/bootloader.asm
+++ b/bootloader.asm
@@ -26,7 +26,7 @@ start:
 
     ; Load 8 sectors of kernel from LBA 1 (MBR=sector 0, kernel=sector 1+)
     mov ah, 0x02
-    mov al, 8              ; SECTORS TO LOAD (tune as kernel grows)
+    mov al, 32             ; SECTORS TO LOAD (tune as kernel grows)
     mov ch, 0
     mov cl, 2              ; Sector 2
     mov dh, 0

--- a/fabric.c
+++ b/fabric.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
-#include "hardware.h"
+#include "keyboard.h"
+#include "mouse.h"
 #include "fabric.h"
 #include "vga.h"
 

--- a/hardware.c
+++ b/hardware.c
@@ -1,4 +1,6 @@
 #include "hardware.h"
+#include "keyboard.h"
+#include "mouse.h"
 
 #define PS2_DATA 0x60
 #define PS2_STATUS 0x64
@@ -33,16 +35,6 @@ static void ps2_wait_output(void) {
 
 bool keyboard_available(void) { return has_keyboard; }
 
-void keyboard_enable(void) {
-    ps2_wait_input();
-    outb(PS2_CMD, 0xAE); // enable first PS/2 port
-    ps2_wait_input();
-    outb(PS2_DATA, 0xF4); // enable scanning
-    ps2_wait_output();
-    uint8_t ack = inb(PS2_DATA);
-    has_keyboard = (ack == 0xFA);
-}
-
 static void ps2_flush_output(void) {
     while (inb(PS2_STATUS) & 0x01)
         (void)inb(PS2_DATA);
@@ -62,59 +54,8 @@ static bool ps2_port_test(int port) {
     return inb(PS2_DATA) == 0x00;
 }
 
-uint8_t keyboard_read_scan(void) {
-    if (inb(PS2_STATUS) & 0x01) {
-        return inb(PS2_DATA);
-    }
-    return 0;
-}
 
 bool mouse_available(void) { return has_mouse; }
-
-void mouse_enable(void) {
-    ps2_wait_input();
-    outb(PS2_CMD, 0xA8);
-    ps2_wait_input();
-    outb(PS2_CMD, 0x20);
-    ps2_wait_output();
-    uint8_t status = inb(PS2_DATA);
-    status |= 0x02;
-    ps2_wait_input();
-    outb(PS2_CMD, 0x60);
-    ps2_wait_input();
-    outb(PS2_DATA, status);
-    ps2_wait_input();
-    outb(PS2_CMD, 0xD4);
-    ps2_wait_input();
-    outb(PS2_DATA, 0xF6);
-    ps2_wait_output();
-    inb(PS2_DATA);
-    ps2_wait_input();
-    outb(PS2_CMD, 0xD4);
-    ps2_wait_input();
-    outb(PS2_DATA, 0xF4);
-    ps2_wait_output();
-    inb(PS2_DATA);
-    has_mouse = true;
-}
-
-bool mouse_read_packet(uint8_t packet[3]) {
-    static int phase = 0;
-    static uint8_t bytes[3];
-    if (!(inb(PS2_STATUS) & 0x01))
-        return false;
-    uint8_t data = inb(PS2_DATA);
-    if (!has_mouse)
-        return false;
-    bytes[phase++] = data;
-    if (phase == 3) {
-        for (int i = 0; i < 3; ++i)
-            packet[i] = bytes[i];
-        phase = 0;
-        return true;
-    }
-    return false;
-}
 
 // Detect basic PS/2 devices. Call only after the IDT is installed to
 // avoid unexpected interrupts resetting the CPU.

--- a/hardware.h
+++ b/hardware.h
@@ -4,17 +4,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-// Initialize keyboard/mouse. IDT should be ready before calling.
+// Initialize PS/2 controller and detect devices. IDT should be ready before
+// calling.  This sets the availability flags for the keyboard and mouse and
+// enables the devices if they are present.
 void hardware_init(void);
 
-// Keyboard
+// Query device availability after hardware_init()
 bool keyboard_available(void);
-void keyboard_enable(void);
-uint8_t keyboard_read_scan(void);
-
-// Mouse
 bool mouse_available(void);
-void mouse_enable(void);
-bool mouse_read_packet(uint8_t packet[3]); // Returns true if a packet was read
 
 #endif

--- a/kernel_main.c
+++ b/kernel_main.c
@@ -1,5 +1,7 @@
 #include <stdint.h>
 #include "hardware.h"
+#include "keyboard.h"
+#include "mouse.h"
 #include "fabric.h"
 #include "vga.h"
 // --- pmm.c prototypes ---

--- a/keyboard.c
+++ b/keyboard.c
@@ -1,0 +1,50 @@
+#include "keyboard.h"
+
+#define PS2_DATA 0x60
+#define PS2_STATUS 0x64
+#define PS2_CMD 0x64
+
+static inline uint8_t inb(uint16_t port) {
+    uint8_t data;
+    __asm__ volatile("inb %1, %0" : "=a"(data) : "Nd"(port));
+    return data;
+}
+
+static inline void outb(uint16_t port, uint8_t data) {
+    __asm__ volatile("outb %0, %1" : : "a"(data), "Nd"(port));
+}
+
+static void ps2_wait_input(void) {
+    for (int i = 0; i < 100000; ++i) {
+        if (!(inb(PS2_STATUS) & 0x02))
+            return;
+    }
+}
+
+static void ps2_wait_output(void) {
+    for (int i = 0; i < 100000; ++i) {
+        if (inb(PS2_STATUS) & 0x01)
+            return;
+    }
+}
+
+void keyboard_enable(void) {
+    ps2_wait_input();
+    outb(PS2_CMD, 0xAE); // enable first PS/2 port
+    ps2_wait_input();
+    outb(PS2_DATA, 0xF4); // enable scanning
+    ps2_wait_output();
+    (void)inb(PS2_DATA); // ack
+}
+
+void keyboard_init(void) {
+    keyboard_enable();
+}
+
+uint8_t keyboard_read_scan(void) {
+    if (inb(PS2_STATUS) & 0x01) {
+        return inb(PS2_DATA);
+    }
+    return 0;
+}
+

--- a/keyboard.h
+++ b/keyboard.h
@@ -1,0 +1,15 @@
+#ifndef KEYBOARD_H
+#define KEYBOARD_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Initialize and enable keyboard if present
+void keyboard_enable(void);
+void keyboard_init(void); // simple wrapper for enable
+
+bool keyboard_available(void); // defined in hardware.c
+uint8_t keyboard_read_scan(void);
+
+#endif
+

--- a/mouse.c
+++ b/mouse.c
@@ -1,0 +1,76 @@
+#include "mouse.h"
+
+#define PS2_DATA 0x60
+#define PS2_STATUS 0x64
+#define PS2_CMD 0x64
+
+static inline uint8_t inb(uint16_t port) {
+    uint8_t data;
+    __asm__ volatile("inb %1, %0" : "=a"(data) : "Nd"(port));
+    return data;
+}
+
+static inline void outb(uint16_t port, uint8_t data) {
+    __asm__ volatile("outb %0, %1" : : "a"(data), "Nd"(port));
+}
+
+static void ps2_wait_input(void) {
+    for (int i = 0; i < 100000; ++i) {
+        if (!(inb(PS2_STATUS) & 0x02))
+            return;
+    }
+}
+
+static void ps2_wait_output(void) {
+    for (int i = 0; i < 100000; ++i) {
+        if (inb(PS2_STATUS) & 0x01)
+            return;
+    }
+}
+
+void mouse_enable(void) {
+    ps2_wait_input();
+    outb(PS2_CMD, 0xA8);
+    ps2_wait_input();
+    outb(PS2_CMD, 0x20);
+    ps2_wait_output();
+    uint8_t status = inb(PS2_DATA);
+    status |= 0x02;
+    ps2_wait_input();
+    outb(PS2_CMD, 0x60);
+    ps2_wait_input();
+    outb(PS2_DATA, status);
+    ps2_wait_input();
+    outb(PS2_CMD, 0xD4);
+    ps2_wait_input();
+    outb(PS2_DATA, 0xF6);
+    ps2_wait_output();
+    inb(PS2_DATA);
+    ps2_wait_input();
+    outb(PS2_CMD, 0xD4);
+    ps2_wait_input();
+    outb(PS2_DATA, 0xF4);
+    ps2_wait_output();
+    inb(PS2_DATA);
+}
+
+void mouse_init(void) {
+    mouse_enable();
+}
+
+bool mouse_read_packet(uint8_t packet[3]) {
+    static int phase = 0;
+    static uint8_t bytes[3];
+    if (!(inb(PS2_STATUS) & 0x01))
+        return false;
+    uint8_t data = inb(PS2_DATA);
+    bytes[phase++] = data;
+    if (phase == 3) {
+        for (int i = 0; i < 3; ++i)
+            packet[i] = bytes[i];
+        phase = 0;
+        return true;
+    }
+    return false;
+}
+

--- a/mouse.h
+++ b/mouse.h
@@ -1,0 +1,15 @@
+#ifndef MOUSE_H
+#define MOUSE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Initialize and enable mouse if present
+void mouse_enable(void);
+void mouse_init(void); // wrapper
+
+bool mouse_available(void); // flag in hardware.c
+bool mouse_read_packet(uint8_t packet[3]);
+
+#endif
+

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -34,6 +34,8 @@ c_files = [
     "pmm.c",
     "idt.c",
     "hardware.c",
+    "keyboard.c",
+    "mouse.c",
     "fabric.c"
 ]
 


### PR DESCRIPTION
## Summary
- split hardware drivers into `keyboard` and `mouse` modules
- update build script for the new driver files
- load more sectors in the bootloader to avoid kernel truncation
- adapt includes to new headers

## Testing
- `python3 setup_bootloader.py` *(fails: FileNotFoundError: 'i686-linux-gnu-gcc')*

------
https://chatgpt.com/codex/tasks/task_e_684cda1d5eac832fb42a4adcce2c70b8