### PR TITLE
Implement PMM/VMM and clean mouse drawing

### DIFF
--- a/fabric.c
+++ b/fabric.c
@@ -10,6 +10,24 @@ static const unsigned char cursor_bitmap[8] = {
     0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0xFE, 0xFE
 };
 
+static uint8_t cursor_back[8][8];
+
+static void save_cursor_back(int x, int y) {
+    for (int row = 0; row < 8; ++row) {
+        for (int col = 0; col < 8; ++col) {
+            cursor_back[row][col] = graphics_get_pixel(x + col, y + row);
+        }
+    }
+}
+
+static void restore_cursor_back(int x, int y) {
+    for (int row = 0; row < 8; ++row) {
+        for (int col = 0; col < 8; ++col) {
+            graphics_put_pixel(x + col, y + row, cursor_back[row][col]);
+        }
+    }
+}
+
 static void draw_cursor(int x, int y, uint8_t color) {
     for (int row = 0; row < 8; ++row) {
         unsigned char bits = cursor_bitmap[row];
@@ -65,6 +83,7 @@ void fabric_ui(uint8_t color) {
     draw_terminal_window();
     int mouse_x = SCREEN_WIDTH / 2;
     int mouse_y = SCREEN_HEIGHT / 2;
+    save_cursor_back(mouse_x, mouse_y);
     draw_cursor(mouse_x, mouse_y, 15);
     int cur_col = 0;
     int cur_row = 0;
@@ -76,13 +95,14 @@ void fabric_ui(uint8_t color) {
         if (mouse_available() && mouse_read_packet(packet)) {
             int dx = (int8_t)packet[1];
             int dy = (int8_t)packet[2];
-            draw_cursor(mouse_x, mouse_y, 1);
+            restore_cursor_back(mouse_x, mouse_y);
             mouse_x += dx;
             mouse_y -= dy;
             if (mouse_x < 0) mouse_x = 0;
             if (mouse_y < 0) mouse_y = 0;
-            if (mouse_x >= SCREEN_WIDTH) mouse_x = SCREEN_WIDTH - 1;
-            if (mouse_y >= SCREEN_HEIGHT) mouse_y = SCREEN_HEIGHT - 1;
+            if (mouse_x >= SCREEN_WIDTH) mouse_x = SCREEN_WIDTH - 8;
+            if (mouse_y >= SCREEN_HEIGHT) mouse_y = SCREEN_HEIGHT - 8;
+            save_cursor_back(mouse_x, mouse_y);
             draw_cursor(mouse_x, mouse_y, 15);
         }
 

--- a/graphics.c
+++ b/graphics.c
@@ -17,6 +17,12 @@ void graphics_put_pixel(int x, int y, uint8_t color) {
     video[y * SCREEN_WIDTH + x] = color;
 }
 
+uint8_t graphics_get_pixel(int x, int y) {
+    if (x < 0 || x >= SCREEN_WIDTH || y < 0 || y >= SCREEN_HEIGHT)
+        return 0;
+    return video[y * SCREEN_WIDTH + x];
+}
+
 void graphics_draw_rect(int x, int y, int w, int h, uint8_t color) {
     for (int j = 0; j < h; ++j) {
         for (int i = 0; i < w; ++i) {

--- a/graphics.h
+++ b/graphics.h
@@ -8,6 +8,7 @@
 void graphics_init(void);
 void graphics_clear(uint8_t color);
 void graphics_put_pixel(int x, int y, uint8_t color);
+uint8_t graphics_get_pixel(int x, int y);
 void graphics_draw_rect(int x, int y, int w, int h, uint8_t color);
 void graphics_draw_char(int x, int y, char c, uint8_t color);
 void graphics_draw_string(int x, int y, const char* str, uint8_t color);

--- a/kernel.asm
+++ b/kernel.asm
@@ -19,3 +19,4 @@ start:
 section .bss
 align 16
 resb 4096        ; 4K scratch space for C (optional)
+kernel_end:

--- a/kernel_main.c
+++ b/kernel_main.c
@@ -4,10 +4,8 @@
 #include "mouse.h"
 #include "fabric.h"
 #include "graphics.h"
-// --- pmm.c prototypes ---
-void init_pmm(uint32_t kernel_end_addr);
-uint32_t alloc_frame(void);
-void free_frame(uint32_t addr);
+#include "pmm.h"
+#include "vmm.h"
 
 // --- idt.c prototype ---
 void idt_init(void);
@@ -20,7 +18,10 @@ struct BootInfo {
 // === Kernel main ===
 void kmain(struct BootInfo* boot) {
     (void)boot;
+    extern uint32_t kernel_end;
     idt_init();
+    init_pmm((uint32_t)&kernel_end);
+    init_vmm();
     hardware_init();
     graphics_init();
     graphics_clear(0);

--- a/pmm.c
+++ b/pmm.c
@@ -1,6 +1,7 @@
 // pmm.c - Simple physical memory manager (frame allocator)
 #include <stdint.h>
 #include <stddef.h>
+#include "pmm.h"
 
 #define FRAME_SIZE 4096        // 4 KiB
 #define TOTAL_MEMORY (16 * 1024 * 1024)  // 16 MiB
@@ -44,5 +45,6 @@ uint32_t alloc_frame() {
 // Free a frame at given physical address
 void free_frame(uint32_t addr) {
     uint32_t frame = addr / FRAME_SIZE;
-    clear_frame(frame);
+    if (frame < FRAME_COUNT && test_frame(frame))
+        clear_frame(frame);
 }

--- a/pmm.h
+++ b/pmm.h
@@ -1,0 +1,9 @@
+#ifndef PMM_H
+#define PMM_H
+#include <stdint.h>
+
+void init_pmm(uint32_t kernel_end_addr);
+uint32_t alloc_frame(void);
+void free_frame(uint32_t addr);
+
+#endif

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -33,6 +33,7 @@ c_files = [
     "vga.c",
     "graphics.c",
     "pmm.c",
+    "vmm.c",
     "idt.c",
     "hardware.c",
     "keyboard.c",

--- a/vmm.c
+++ b/vmm.c
@@ -1,0 +1,49 @@
+#include "vmm.h"
+#include "pmm.h"
+
+#define PAGE_PRESENT 0x1
+#define PAGE_WRITE   0x2
+#define PAGE_USER    0x4
+
+static uint32_t* kernel_directory;
+
+static inline void load_cr3(uint32_t val) {
+    __asm__ volatile("mov %0, %%cr3" :: "r"(val));
+}
+
+static inline uint32_t read_cr0(void) {
+    uint32_t val; __asm__ volatile("mov %%cr0, %0" : "=r"(val)); return val; }
+
+static inline void write_cr0(uint32_t val) {
+    __asm__ volatile("mov %0, %%cr0" :: "r"(val));
+}
+
+static void enable_paging(uint32_t* pd) {
+    load_cr3((uint32_t)pd);
+    uint32_t cr0 = read_cr0();
+    cr0 |= 0x80000000; // PG bit
+    write_cr0(cr0);
+}
+
+void init_vmm(void) {
+    kernel_directory = (uint32_t*)alloc_frame();
+    uint32_t* first_table = (uint32_t*)alloc_frame();
+    for (int i = 0; i < 1024; ++i) {
+        first_table[i] = (i * 0x1000) | PAGE_PRESENT | PAGE_WRITE;
+        kernel_directory[i] = 0;
+    }
+    kernel_directory[0] = ((uint32_t)first_table) | PAGE_PRESENT | PAGE_WRITE;
+    enable_paging(kernel_directory);
+}
+
+uint32_t* vmm_create_address_space(void) {
+    uint32_t* pd = (uint32_t*)alloc_frame();
+    for (int i = 0; i < 1024; ++i)
+        pd[i] = kernel_directory[i];
+    return pd;
+}
+
+void vmm_switch(uint32_t* pd_phys) {
+    load_cr3((uint32_t)pd_phys);
+}
+

--- a/vmm.h
+++ b/vmm.h
@@ -1,0 +1,9 @@
+#ifndef VMM_H
+#define VMM_H
+#include <stdint.h>
+
+void init_vmm(void);
+uint32_t* vmm_create_address_space(void);
+void vmm_switch(uint32_t* pd_phys);
+
+#endif


### PR DESCRIPTION
## Summary
- save/restore pixels under cursor so moving the mouse no longer leaves artifacts
- expose `graphics_get_pixel`
- add physical memory manager header and guard against double free
- introduce simple paging-based virtual memory manager
- hook PMM and VMM into kernel startup
- add `kernel_end` symbol for memory initialization
- include `vmm.c` in build script

## Testing
- `python3 setup_bootloader.py` *(fails: FileNotFoundError: 'i686-linux-gnu-gcc')*

------
https://chatgpt.com/codex/tasks/task_e_684d9aceaa08832fb3aa6d76326917e4