### PR TITLE
Fix UI scaling and background color

### DIFF
--- a/bootloader.asm
+++ b/bootloader.asm
@@ -23,6 +23,9 @@ start:
     ; Get conventional memory size (KB) via BIOS
     int 0x12
     mov [BOOTINFO_ADDR], ax
+    ; Store default screen resolution (will be patched by kernel if needed)
+    mov dword [BOOTINFO_ADDR + 4], 1920
+    mov dword [BOOTINFO_ADDR + 8], 1080
 
     ; Load 8 sectors of kernel from LBA 1 (MBR=sector 0, kernel=sector 1+)
     mov ah, 0x02

--- a/fabric.c
+++ b/fabric.c
@@ -52,15 +52,10 @@ static const char scancode_ascii[128] = {
 
 // Draw a simple bordered window filling most of the screen
 static void draw_window(uint8_t color) {
-    graphics_draw_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, color);
+    graphics_draw_rect(0, 0, screen_width, screen_height, color);
 }
 
-static const int term_x = 30;
-static const int term_y = 40;
-static const int term_w = SCREEN_WIDTH - 60;
-static const int term_h = SCREEN_HEIGHT - 80;
-
-static void draw_terminal_window(void) {
+static void draw_terminal_window(int term_x, int term_y, int term_w, int term_h) {
     graphics_draw_rect(term_x, term_y, term_w, term_h, 1);
     for (int i = 0; i < term_w; ++i) {
         graphics_put_pixel(term_x + i, term_y, 15);
@@ -78,11 +73,17 @@ static void draw_terminal_window(void) {
 }
 
 void fabric_ui(uint8_t color) {
-    graphics_clear(0);
+    graphics_clear(color);
     draw_window(color);
-    draw_terminal_window();
-    int mouse_x = SCREEN_WIDTH / 2;
-    int mouse_y = SCREEN_HEIGHT / 2;
+
+    int term_x = 30;
+    int term_y = 40;
+    int term_w = screen_width - 60;
+    int term_h = screen_height - 80;
+    draw_terminal_window(term_x, term_y, term_w, term_h);
+
+    int mouse_x = screen_width / 2;
+    int mouse_y = screen_height / 2;
     save_cursor_back(mouse_x, mouse_y);
     draw_cursor(mouse_x, mouse_y, 15);
     int cur_col = 0;
@@ -100,8 +101,8 @@ void fabric_ui(uint8_t color) {
             mouse_y -= dy;
             if (mouse_x < 0) mouse_x = 0;
             if (mouse_y < 0) mouse_y = 0;
-            if (mouse_x >= SCREEN_WIDTH) mouse_x = SCREEN_WIDTH - 8;
-            if (mouse_y >= SCREEN_HEIGHT) mouse_y = SCREEN_HEIGHT - 8;
+            if (mouse_x >= screen_width) mouse_x = screen_width - 8;
+            if (mouse_y >= screen_height) mouse_y = screen_height - 8;
             save_cursor_back(mouse_x, mouse_y);
             draw_cursor(mouse_x, mouse_y, 15);
         }

--- a/graphics.c
+++ b/graphics.c
@@ -2,25 +2,28 @@
 
 static volatile uint8_t* const video = (volatile uint8_t*)0xA0000;
 
+int screen_width = DEFAULT_SCREEN_WIDTH;
+int screen_height = DEFAULT_SCREEN_HEIGHT;
+
 void graphics_init(void) {
     // graphics mode already set by bootloader
 }
 
 void graphics_clear(uint8_t color) {
-    for (int i = 0; i < SCREEN_WIDTH * SCREEN_HEIGHT; ++i)
+    for (int i = 0; i < screen_width * screen_height; ++i)
         video[i] = color;
 }
 
 void graphics_put_pixel(int x, int y, uint8_t color) {
-    if (x < 0 || x >= SCREEN_WIDTH || y < 0 || y >= SCREEN_HEIGHT)
+    if (x < 0 || x >= screen_width || y < 0 || y >= screen_height)
         return;
-    video[y * SCREEN_WIDTH + x] = color;
+    video[y * screen_width + x] = color;
 }
 
 uint8_t graphics_get_pixel(int x, int y) {
-    if (x < 0 || x >= SCREEN_WIDTH || y < 0 || y >= SCREEN_HEIGHT)
+    if (x < 0 || x >= screen_width || y < 0 || y >= screen_height)
         return 0;
-    return video[y * SCREEN_WIDTH + x];
+    return video[y * screen_width + x];
 }
 
 void graphics_draw_rect(int x, int y, int w, int h, uint8_t color) {

--- a/graphics.h
+++ b/graphics.h
@@ -2,8 +2,11 @@
 #define GRAPHICS_H
 #include <stdint.h>
 
-#define SCREEN_WIDTH 1920
-#define SCREEN_HEIGHT 1080
+#define DEFAULT_SCREEN_WIDTH 1920
+#define DEFAULT_SCREEN_HEIGHT 1080
+
+extern int screen_width;
+extern int screen_height;
 
 void graphics_init(void);
 void graphics_clear(uint8_t color);

--- a/kernel_main.c
+++ b/kernel_main.c
@@ -13,17 +13,20 @@ void idt_init(void);
 
 struct BootInfo {
     uint32_t mem_kb;
+    uint32_t width;
+    uint32_t height;
 };
 
 // === Kernel main ===
 void kmain(struct BootInfo* boot) {
-    (void)boot;
+    screen_width = (boot && boot->width) ? boot->width : DEFAULT_SCREEN_WIDTH;
+    screen_height = (boot && boot->height) ? boot->height : DEFAULT_SCREEN_HEIGHT;
     extern uint32_t kernel_end;
     idt_init();
     init_pmm((uint32_t)&kernel_end);
     init_vmm();
     hardware_init();
     graphics_init();
-    graphics_clear(0);
-    fabric_ui(12);
+    graphics_clear(8);
+    fabric_ui(8);
 }


### PR DESCRIPTION
## Summary
- pass screen resolution info from bootloader
- use runtime screen width/height in graphics routines and UI
- switch fabric UI and kernel default background to dark gray

## Testing
- `python3 setup_bootloader.py` *(fails: FileNotFoundError: No such file or directory: 'i686-linux-gnu-gcc')*

------
https://chatgpt.com/codex/tasks/task_e_684d9ed5920c832fb4ec6d2bfd39fd34