### PR TITLE
Fix kernel_end linker symbol

### DIFF
--- a/kernel.asm
+++ b/kernel.asm
@@ -2,6 +2,7 @@
 BITS 32
 
 global start
+global kernel_end
 extern kmain
 
 section .text


### PR DESCRIPTION
## Summary
- export `kernel_end` from `kernel.asm`

## Testing
- `python3 setup_bootloader.py` *(fails to create ISO due to missing `mkisofs`, but kernel builds successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684d9c035bd0832f9d9682b508d3d5b2